### PR TITLE
Improve SSL settings in Nginx conf.

### DIFF
--- a/templates/etc/nginx/router.conf.mustache
+++ b/templates/etc/nginx/router.conf.mustache
@@ -115,6 +115,43 @@ http {
   gzip_types application/atom+xml application/javascript application/json application/rss+xml application/x-javascript application/xml text/css text/csv text/javascript text/plain text/xml;
   gzip_vary on;
 
+  {{#nginx.ssl_protocols}}
+  ssl_protocols {{nginx.ssl_protocols}};
+  {{/nginx.ssl_protocols}}
+  {{^nginx.ssl_protocols}}
+  # Disable SSLv3(enabled by default since nginx 0.8.19) since it's less secure then TLS http://en.wikipedia.org/wiki/Secure_Sockets_Layer#SSL_3.0
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  {{/ssl_protocols}}
+
+  {{#nginx.ssl_ciphers}}
+  ssl_ciphers {{nginx.ssl_ciphers}};
+  {{/nginx.ssl_ciphers}}
+  {{^nginx.ssl_ciphers}}
+  # Ciphers chosen for forward secrecy and compatibility
+  # https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28default.29
+  ssl_ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS;
+  {{/nginx.ssl_ciphers}}
+
+  # Enable session resumption to improve https performance
+  {{#nginx.ssl_session_cache}}
+  ssl_session_cache {{nginx.ssl_session_cache}};
+  {{/nginx.ssl_session_cache}}
+  {{^nginx.ssl_session_cache}}
+  ssl_session_cache shared:SSL:50m;
+  {{/nginx.ssl_session_cache}}
+  ssl_session_timeout 24h;
+  ssl_session_tickets off;
+  ssl_buffer_size 1400;
+
+  # Enable server-side protection from BEAST attacks
+  ssl_prefer_server_ciphers on;
+  ssl_ecdh_curve secp384r1;
+
+  {{#nginx.dhparam}}
+  # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+  ssl_dhparam {{nginx.dhparam}};
+  {{/nginx.dhparam}}
+
   {{#nginx.server_names_hash_bucket_size}}
     server_names_hash_bucket_size {{nginx.server_names_hash_bucket_size}};
   {{/nginx.server_names_hash_bucket_size}}
@@ -173,6 +210,12 @@ http {
     {{/ssl_cert}}
 
     include ./frontend_defaults.conf;
+
+    {{#http_strict_transport_security}}
+    # Enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
+    # to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
+    add_header Strict-Transport-Security "{{http_strict_transport_security}}" always;
+    {{/http_strict_transport_security}}
 
     {{#rewrites}}
     rewrite {{.}};


### PR DESCRIPTION
Re-created from https://github.com/NREL/api-umbrella/pull/236 but now from right fork.

Set up strong SSL security on the Nginx webserver. This way we have a strong and future proof ssl configuration and we get an A+ on the Qually Labs SSL Test.

Example: https://www.ssllabs.com/ssltest/analyze.html?d=nightly.umbrella.apinf.io (A+)

Example of api-umbrella.yml:

```
nginx:
  server_names_hash_bucket_size: 128
  dhparam: /etc/ssl/private/dhparams.pem
  ssl_session_cache: "shared:SSL:10m"
  ssl_ciphers: "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH"
  ssl_protocols: "TLSv1 TLSv1.1 TLSv1.2"
hosts:
  - hostname: example.com
    default: true
    ssl_cert: /etc/keys/example.com/fullchain.pem
    ssl_cert_key: /etc/keys/example.com/privkey.pem
    http_strict_transport_security: "max-age=31536000; includeSubDomains; preload"
```

This request based on instructions and tutorials:

- https://wiki.mozilla.org/Security/Server_Side_TLS
- https://cipherli.st/ (https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html)
- https://github.com/h5bp/server-configs-nginx

That changes related to #24, #234

/cc @brylie @GUI 

