### PR TITLE
Notify admin

### DIFF
--- a/src/api-umbrella/web-app/app/controllers/api/v1/users_controller.rb
+++ b/src/api-umbrella/web-app/app/controllers/api/v1/users_controller.rb
@@ -60,10 +60,13 @@ class Api::V1::UsersController < Api::V1::BaseController
           send_welcome_email = true
         end
 
+        if(!send_notify_email && ApiUmbrellaConfig[:send_notify_email].to_s == "true")
+          send_notify_email = true
+        end
+
         if(send_welcome_email)
           ApiUserMailer.delay(:queue => "mailers").signup_email(@api_user, params[:options] || {})
         end
-
         if(send_notify_email)
           ApiUserMailer.delay(:queue => "mailers").notify_api_admin(@api_user)
         end

--- a/src/api-umbrella/web-app/app/controllers/api/v1/users_controller.rb
+++ b/src/api-umbrella/web-app/app/controllers/api/v1/users_controller.rb
@@ -60,7 +60,7 @@ class Api::V1::UsersController < Api::V1::BaseController
           send_welcome_email = true
         end
 
-        if(!send_notify_email && ApiUmbrellaConfig[:send_notify_email].to_s == "true")
+        if(!send_notify_email && ApiUmbrellaConfig[:web][:send_notify_email].to_s == "true")
           send_notify_email = true
         end
 

--- a/src/api-umbrella/web-app/app/controllers/api/v1/users_controller.rb
+++ b/src/api-umbrella/web-app/app/controllers/api/v1/users_controller.rb
@@ -49,18 +49,23 @@ class Api::V1::UsersController < Api::V1::BaseController
 
     respond_to do |format|
       if(@api_user.save)
-        send_email = (params[:options] && params[:options][:send_welcome_email].to_s == "true")
+        send_welcome_email = (params[:options] && params[:options][:send_welcome_email].to_s == "true")
+        send_notify_email = (params[:options] && params[:options][:send_notify_email].to_s == "true")
 
         # For the admin tool, it's easier to have this attribute on the user
         # model, rather than options, so check there for whether we should send
         # e-mail. Also note that for backwards compatibility, we only check for
         # the presence of this attribute, and not it's actual value.
-        if(!send_email && params[:user] && params[:user][:send_welcome_email])
-          send_email = true
+        if(!send_welcome_email && params[:user] && params[:user][:send_welcome_email])
+          send_welcome_email = true
         end
 
-        if(send_email)
+        if(send_welcome_email)
           ApiUserMailer.delay(:queue => "mailers").signup_email(@api_user, params[:options] || {})
+        end
+
+        if(send_notify_email)
+          ApiUserMailer.delay(:queue => "mailers").notify_api_admin(@api_user)
         end
 
         format.json { render("show", :status => :created, :location => api_v1_user_url(@api_user)) }

--- a/src/api-umbrella/web-app/app/mailers/api_user_mailer.rb
+++ b/src/api-umbrella/web-app/app/mailers/api_user_mailer.rb
@@ -23,4 +23,16 @@ class ApiUserMailer < ActionMailer::Base
       :from => MailSanitizer.sanitize_address(from),
       :to => MailSanitizer.sanitize_address(user.email)
   end
+
+  def notify_api_admin(user)
+    @user = user
+
+    to = ApiUmbrellaConfig[:admin_notify_email].presence || ApiUmbrellaConfig[:web][:contact_form_email]
+
+    full_name = "#{@user.first_name} #{@user.last_name}"
+
+    mail :subject => "#{full_name} just subscribed",
+         :from => MailSanitizer.sanitize_address(user.email),
+         :to => MailSanitizer.sanitize_address(to)
+  end
 end

--- a/src/api-umbrella/web-app/app/mailers/api_user_mailer.rb
+++ b/src/api-umbrella/web-app/app/mailers/api_user_mailer.rb
@@ -27,12 +27,12 @@ class ApiUserMailer < ActionMailer::Base
   def notify_api_admin(user)
     @user = user
 
-    to = ApiUmbrellaConfig[:admin_notify_email].presence || ApiUmbrellaConfig[:web][:contact_form_email]
+    to = ApiUmbrellaConfig[:web][:admin_notify_email].presence || ApiUmbrellaConfig[:web][:contact_form_email]
 
     full_name = "#{@user.first_name} #{@user.last_name}"
-
+    from = "noreply@#{ApiUmbrellaConfig[:web][:default_host]}"
     mail :subject => "#{full_name} just subscribed",
-         :from => MailSanitizer.sanitize_address(user.email),
+         :from => MailSanitizer.sanitize_address(from),
          :to => MailSanitizer.sanitize_address(to)
   end
 end

--- a/src/api-umbrella/web-app/app/views/api_user_mailer/notify_api_admin.erb
+++ b/src/api-umbrella/web-app/app/views/api_user_mailer/notify_api_admin.erb
@@ -1,0 +1,39 @@
+<h1><%= @user.first_name %> <%= @user.last_name %> just subscribed</h1>
+<h2>Description</h2>
+
+<p>
+    <%= @user.use_description %>
+</p>
+
+<h2>Extra-informations</h2>
+
+<table>
+    <tr>
+        <td>Email</td>
+        <td><%= @user.email %></td>
+    </tr>
+    <% unless @user.registration_source.blank? -%>
+        <tr>
+            <td>Source</td>
+            <td><%= @user.registration_source %></td>
+        </tr>
+    <% end -%>
+    <% unless @user.website.blank? -%>
+        <tr>
+            <td>Website</td>
+            <td><%= @user.website %></td>
+        </tr>
+    <% end -%>
+    <tr>
+        <td>IP Adress</td>
+        <td><%= @user.registration_ip %></td>
+    </tr>
+    <tr>
+        <td>Referer</td>
+        <td><%= @user.registration_referer %></td>
+    </tr>
+    <tr>
+        <td>Origin</td>
+        <td><%= @user.registration_origin %></td>
+    </tr>
+</table>

--- a/src/api-umbrella/web-app/spec/controllers/api/v1/users_controller_spec.rb
+++ b/src/api-umbrella/web-app/spec/controllers/api/v1/users_controller_spec.rb
@@ -992,12 +992,23 @@ describe Api::V1::UsersController do
         Delayed::Worker.delay_jobs = true
       end
 
-      it "sends a notify e-mail to be sent when requested" do
+      it "sends a notify e-mail to be sent when requested in query" do
         admin_token_auth(@admin)
         expect do
           p = params
           p[:options] = { :send_notify_email => true }
           post :create, p
+        end.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+
+      it "sends a notify e-mail to be sent when requested in the config" do
+        admin_token_auth(@admin)
+        expect do
+          p = params
+          ApiUmbrellaConfig[:send_notify_email] = true
+          post :create, p
+          ApiUmbrellaConfig[:send_notify_email] = false
+
         end.to change { ActionMailer::Base.deliveries.count }.by(1)
       end
 

--- a/src/api-umbrella/web-app/spec/controllers/api/v1/users_controller_spec.rb
+++ b/src/api-umbrella/web-app/spec/controllers/api/v1/users_controller_spec.rb
@@ -1005,9 +1005,9 @@ describe Api::V1::UsersController do
         admin_token_auth(@admin)
         expect do
           p = params
-          ApiUmbrellaConfig[:send_notify_email] = true
+          ApiUmbrellaConfig[:web][:send_notify_email] = true
           post :create, p
-          ApiUmbrellaConfig[:send_notify_email] = false
+          ApiUmbrellaConfig[:web][:send_notify_email] = false
 
         end.to change { ActionMailer::Base.deliveries.count }.by(1)
       end

--- a/src/api-umbrella/web-app/spec/mailers/api_user_mailer_spec.rb
+++ b/src/api-umbrella/web-app/spec/mailers/api_user_mailer_spec.rb
@@ -91,6 +91,7 @@ describe ApiUserMailer do
   describe "signup_email" do
     before(:each) do
       ApiUmbrellaConfig[:web][:contact_form_email] = "aaa@bbb.com"
+      ApiUmbrellaConfig[:web][:default_host] = "localhost.com"
     end
 
     let(:api_user) do
@@ -114,7 +115,7 @@ describe ApiUserMailer do
     end
 
     it "the receiver can be overwrited by the admin " do
-      ApiUmbrellaConfig[:admin_notify_email] = "ccc@ddd.com"
+      ApiUmbrellaConfig[:web][:admin_notify_email] = "ccc@ddd.com"
       subject
       expect(ActionMailer::Base.deliveries.first.to).to eq ["ccc@ddd.com"]
     end
@@ -122,6 +123,11 @@ describe ApiUserMailer do
     it "send an email with the name of the person in the subject" do
       subject
       expect(ActionMailer::Base.deliveries.first.subject).to eq "aaa bbb just subscribed"
+    end
+
+    it "send an email from the server name" do
+      subject
+      expect(ActionMailer::Base.deliveries.first.from).to eq ["noreply@localhost.com"]
     end
 
     it "send an email with usage in the body" do

--- a/src/api-umbrella/web-app/spec/mailers/api_user_mailer_spec.rb
+++ b/src/api-umbrella/web-app/spec/mailers/api_user_mailer_spec.rb
@@ -1,88 +1,129 @@
 require "spec_helper"
 
 describe ApiUserMailer do
-  describe "OSVDB-131677 security" do
-    it "accepts recipients without newlines" do
-      expect do
-        api_user = FactoryGirl.create(:api_user, :email => "foo@example.com")
-        ApiUserMailer.signup_email(api_user, {}).deliver
-      end.to change { ActionMailer::Base.deliveries.count }.by(1)
-    end
-
-    it "rejects recipients with newlines" do
-      expect do
+  describe "signup_email" do
+    describe "OSVDB-131677 security" do
+      it "accepts recipients without newlines" do
         expect do
-          api_user = FactoryGirl.create(:api_user, :email => "foo@example.com\nfoo")
+          api_user = FactoryGirl.create(:api_user, :email => "foo@example.com")
           ApiUserMailer.signup_email(api_user, {}).deliver
-        end.to raise_error(MailSanitizer::InvalidAddress)
-      end.to change { ActionMailer::Base.deliveries.count }.by(0)
-    end
+        end.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
 
-    it "rejects recipients with carriage returns" do
-      expect do
+      it "rejects recipients with newlines" do
         expect do
-          api_user = FactoryGirl.create(:api_user, :email => "foo@example.com\rfoo")
-          ApiUserMailer.signup_email(api_user, {}).deliver
-        end.to raise_error(MailSanitizer::InvalidAddress)
-      end.to change { ActionMailer::Base.deliveries.count }.by(0)
-    end
+          expect do
+            api_user = FactoryGirl.create(:api_user, :email => "foo@example.com\nfoo")
+            ApiUserMailer.signup_email(api_user, {}).deliver
+          end.to raise_error(MailSanitizer::InvalidAddress)
+        end.to change { ActionMailer::Base.deliveries.count }.by(0)
+      end
 
-    it "accepts recipients 500 chars or less" do
-      expect do
-        api_user = FactoryGirl.create(:api_user, :email => "#{"o" * 488}@example.com")
-        ApiUserMailer.signup_email(api_user, {}).deliver
-      end.to change { ActionMailer::Base.deliveries.count }.by(1)
-    end
-
-    it "rejects recipients greater than 500 chars" do
-      expect do
+      it "rejects recipients with carriage returns" do
         expect do
-          api_user = FactoryGirl.create(:api_user, :email => "#{"o" * 489}@example.com")
+          expect do
+            api_user = FactoryGirl.create(:api_user, :email => "foo@example.com\rfoo")
+            ApiUserMailer.signup_email(api_user, {}).deliver
+          end.to raise_error(MailSanitizer::InvalidAddress)
+        end.to change { ActionMailer::Base.deliveries.count }.by(0)
+      end
+
+      it "accepts recipients 500 chars or less" do
+        expect do
+          api_user = FactoryGirl.create(:api_user, :email => "#{"o" * 488}@example.com")
           ApiUserMailer.signup_email(api_user, {}).deliver
-        end.to raise_error(MailSanitizer::InvalidAddress)
-      end.to change { ActionMailer::Base.deliveries.count }.by(0)
-    end
+        end.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
 
-    it "accepts from addresses without newlines" do
-      expect do
-        api_user = FactoryGirl.create(:api_user)
-        ApiUserMailer.signup_email(api_user, { :email_from_address => "foo@example.com" }).deliver
-      end.to change { ActionMailer::Base.deliveries.count }.by(1)
-    end
+      it "rejects recipients greater than 500 chars" do
+        expect do
+          expect do
+            api_user = FactoryGirl.create(:api_user, :email => "#{"o" * 489}@example.com")
+            ApiUserMailer.signup_email(api_user, {}).deliver
+          end.to raise_error(MailSanitizer::InvalidAddress)
+        end.to change { ActionMailer::Base.deliveries.count }.by(0)
+      end
 
-    it "rejects from addresses with newlines" do
-      expect do
+      it "accepts from addresses without newlines" do
         expect do
           api_user = FactoryGirl.create(:api_user)
-          ApiUserMailer.signup_email(api_user, { :email_from_address => "foo@example.com\nfoo" }).deliver
-        end.to raise_error(MailSanitizer::InvalidAddress)
-      end.to change { ActionMailer::Base.deliveries.count }.by(0)
-    end
+          ApiUserMailer.signup_email(api_user, { :email_from_address => "foo@example.com" }).deliver
+        end.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
 
-    it "rejects from addresses with carriage returns" do
-      expect do
+      it "rejects from addresses with newlines" do
+        expect do
+          expect do
+            api_user = FactoryGirl.create(:api_user)
+            ApiUserMailer.signup_email(api_user, { :email_from_address => "foo@example.com\nfoo" }).deliver
+          end.to raise_error(MailSanitizer::InvalidAddress)
+        end.to change { ActionMailer::Base.deliveries.count }.by(0)
+      end
+
+      it "rejects from addresses with carriage returns" do
+        expect do
+          expect do
+            api_user = FactoryGirl.create(:api_user)
+            ApiUserMailer.signup_email(api_user, { :email_from_address => "foo@example.com\rfoo" }).deliver
+          end.to raise_error(MailSanitizer::InvalidAddress)
+        end.to change { ActionMailer::Base.deliveries.count }.by(0)
+      end
+
+      it "accepts from addresses 500 chars or less" do
         expect do
           api_user = FactoryGirl.create(:api_user)
-          ApiUserMailer.signup_email(api_user, { :email_from_address => "foo@example.com\rfoo" }).deliver
-        end.to raise_error(MailSanitizer::InvalidAddress)
-      end.to change { ActionMailer::Base.deliveries.count }.by(0)
-    end
+          ApiUserMailer.signup_email(api_user, { :email_from_address => "#{"o" * 488}@example.com" }).deliver
+        end.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
 
-    it "accepts from addresses 500 chars or less" do
-      expect do
-        api_user = FactoryGirl.create(:api_user)
-        ApiUserMailer.signup_email(api_user, { :email_from_address => "#{"o" * 488}@example.com" }).deliver
-      end.to change { ActionMailer::Base.deliveries.count }.by(1)
-    end
-
-    it "rejects from addresses greater than 500 chars" do
-      expect do
+      it "rejects from addresses greater than 500 chars" do
         expect do
-          api_user = FactoryGirl.create(:api_user)
-          ApiUserMailer.signup_email(api_user, { :email_from_address => "#{"o" * 489}@example.com" }).deliver
-        end.to raise_error(MailSanitizer::InvalidAddress)
-      end.to change { ActionMailer::Base.deliveries.count }.by(0)
+          expect do
+            api_user = FactoryGirl.create(:api_user)
+            ApiUserMailer.signup_email(api_user, { :email_from_address => "#{"o" * 489}@example.com" }).deliver
+          end.to raise_error(MailSanitizer::InvalidAddress)
+        end.to change { ActionMailer::Base.deliveries.count }.by(0)
+      end
+
+    end
+  end
+
+  describe "signup_email" do
+    before(:each) do
+      ApiUmbrellaConfig[:web][:contact_form_email] = "aaa@bbb.com"
     end
 
+    let(:api_user) { FactoryGirl.create(:api_user,
+                                        :first_name => "aaa",
+                                        :last_name => "bbb",
+                                        :use_description => "I WANNA DO EVERYTHING",
+                                        :email => "foo@example.com") }
+
+    subject { ApiUserMailer.notify_api_admin(api_user).deliver }
+
+    it "send an email " do
+      expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+
+    it "send an email to the contact email" do
+      subject
+      expect(ActionMailer::Base.deliveries.first.to).to eq ["aaa@bbb.com"]
+    end
+
+    it "the receiver can be overwrited by the admin " do
+      ApiUmbrellaConfig[:admin_notify_email] = "ccc@ddd.com"
+      subject
+      expect(ActionMailer::Base.deliveries.first.to).to eq ["ccc@ddd.com"]
+    end
+
+    it "send an email with the name of the person in the subject" do
+      subject
+      expect(ActionMailer::Base.deliveries.first.subject).to eq "aaa bbb just subscribed"
+    end
+
+    it "send an email with usage in the body" do
+      subject
+      expect(ActionMailer::Base.deliveries.first.encoded).to include "I WANNA DO EVERYTHING"
+    end
   end
 end

--- a/src/api-umbrella/web-app/spec/mailers/api_user_mailer_spec.rb
+++ b/src/api-umbrella/web-app/spec/mailers/api_user_mailer_spec.rb
@@ -93,11 +93,14 @@ describe ApiUserMailer do
       ApiUmbrellaConfig[:web][:contact_form_email] = "aaa@bbb.com"
     end
 
-    let(:api_user) { FactoryGirl.create(:api_user,
-                                        :first_name => "aaa",
-                                        :last_name => "bbb",
-                                        :use_description => "I WANNA DO EVERYTHING",
-                                        :email => "foo@example.com") }
+    let(:api_user) do
+      FactoryGirl.create(
+          :api_user,
+          :first_name => "aaa",
+          :last_name => "bbb",
+          :use_description => "I WANNA DO EVERYTHING",
+          :email => "foo@example.com")
+    end
 
     subject { ApiUserMailer.notify_api_admin(api_user).deliver }
 


### PR DESCRIPTION
if the config `send_notify_email` is set to `true` then the signup of a new key send a mail to the administrator of Umbrella

**NOTE** : 
 * I wasn't able to run the application and check the mail. Nonetheless the tests are green.
 * I don't know Rails so feedback is welcome