### PR TITLE
Switch analytics logging of "request_at" to be end time (not start time)

### DIFF
--- a/src/api-umbrella/proxy/hooks/log_initial_proxy.lua
+++ b/src/api-umbrella/proxy/hooks/log_initial_proxy.lua
@@ -119,7 +119,7 @@ local function log_request()
     id = id,
     request_accept = truncate_header(request_headers["accept"], 200),
     request_accept_encoding = truncate_header(request_headers["accept-encoding"], 200),
-    request_at = (ngx_var.msec - (tonumber(ngx_var.request_time) or 0)),
+    request_at = tonumber(ngx_var.msec),
     request_basic_auth_username = ngx_var.remote_user,
     request_connection = truncate_header(request_headers["connection"], 200),
     request_content_type = truncate_header(request_headers["content-type"], 200),

--- a/test/integration/logging.js
+++ b/test/integration/logging.js
@@ -1169,6 +1169,36 @@ describe('logging', function() {
     }.bind(this));
   });
 
+  it('logs the request_at as the time the request finishes (not when it begins)', function(done) {
+    this.timeout(15000);
+
+    var requestStart = Date.now();
+    request.get('http://localhost:9080/delay/3000', this.options, function(error, response) {
+      var requestEnd = Date.now();
+      should.not.exist(error);
+      response.statusCode.should.eql(200);
+
+      waitForLog(this.uniqueQueryId, function(error, response, hit, record) {
+        should.not.exist(error);
+
+        var recordResponseTime = record.response_time;
+        recordResponseTime.should.be.gte(2500);
+        recordResponseTime.should.be.lte(3500);
+
+        var localResponseTime = requestEnd - requestStart;
+        localResponseTime.should.be.gte(2500);
+        localResponseTime.should.be.lte(3500);
+
+        var diffExpectedEndTime = requestEnd - record.request_at;
+        diffExpectedEndTime.should.be.gte(-500);
+        diffExpectedEndTime.should.be.lte(500);
+
+        done();
+      });
+    }.bind(this));
+  });
+
+
   it('successfully logs query strings when the field first indexed was a date, but later queries are not (does not attempt to map fields into dates)', function(done) {
     this.timeout(30000);
 


### PR DESCRIPTION
Previously, the "request_at" field in the analytics was the timestamp of when the request began. This changes the behavior so "request_at" is now the timestamp of when the response finished.

Using the start time caused potential issues with the new hadoop analytics processing for long-running requests. Because we partition the live incoming data by the request_at timestamp, it meant that if a request took 3 minutes to complete, we would suddenly be inserting data into the partition from 3 minutes ago. This complicates data processing, since we have to deal with out-of-order insertion timestamps (which vary depending on how long the requests take).

By switching to use the end time, data processing is much simpler, since the timestamps should always be incrementing.

Using the end time also better aligns our timestamps with the timestamps nginx logs in the access.log file (which can be useful for debugging).