### PR TITLE
Add curl as core package dependency

### DIFF
--- a/build/package_dependencies.sh
+++ b/build/package_dependencies.sh
@@ -19,6 +19,7 @@ if [ -f /etc/redhat-release ]; then
   core_package_dependencies=(
     # General
     bash
+    curl
     glibc
     libffi
     libuuid
@@ -94,6 +95,7 @@ elif [ -f /etc/debian_version ]; then
   core_package_dependencies=(
     # General
     bash
+    curl
     libc6
     libffi$libffi_version
     libncurses5


### PR DESCRIPTION
* 	Add curl as core package dependency, for correct work "[api-umbrella-geoip-auto-updater](https://github.com/NREL/api-umbrella/blob/master/bin/api-umbrella-geoip-auto-updater#L43)".

Closes #290