### PR TITLE
Update Docker install instructions $PWD containing spaces

### DIFF
--- a/website/source/install.html.erb
+++ b/website/source/install.html.erb
@@ -51,7 +51,7 @@ header: Install
       - your.email@example.com</pre>
 
     <p>Start API Umbrella:</p>
-    <pre>$ docker run -d --name=api-umbrella -p 80:80 -p 443:443 -v $PWD/config:/etc/api-umbrella nrel/api-umbrella</pre>
+    <pre>$ docker run -d --name=api-umbrella -p 80:80 -p 443:443 -v config:/etc/api-umbrella nrel/api-umbrella</pre>
   </div>
 
   <% packages.each do |id, distro| %>


### PR DESCRIPTION
When current dir contains spaces,
-v $PWD/config:/etc/api-umbrella
won't expand correctly and command fails, as $PWD is not necessary in Docker command, we can just forget about it.