### PR TITLE
Add line to Trafficservers records.config to resolve /etc/hosts file

### DIFF
--- a/templates/etc/trafficserver/records.config.mustache
+++ b/templates/etc/trafficserver/records.config.mustache
@@ -208,6 +208,9 @@ CONFIG proxy.config.hostdb.fail.timeout INT {{dns_resolver.negative_ttl}}
 # Use more standard round-robin for DNS results (rather than sticky).
 CONFIG proxy.config.hostdb.strict_round_robin INT 1
 
+# Resolve hosts from /etc/hosts file
+CONFIG proxy.config.hostdb.host_file.path STRING /etc/hosts
+
 # Enable so_keepalive on the incoming and outgoing sockets to better detect
 # keepalive hangups.
 CONFIG proxy.config.net.sock_option_flag_in INT 7


### PR DESCRIPTION
Related to issue: https://github.com/NREL/api-umbrella/issues/493

By default Trafficserver doesn't resolve the /etc/hosts file.
The `proxy.config.hostdb.host_file.path` setting ensures that it does.