### PR TITLE
Improve admin login performance

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1982,6 +1982,13 @@ CREATE INDEX api_users_created_at_idx ON api_umbrella.api_users USING btree (cre
 
 
 --
+-- Name: api_users_email_created_at_idx; Type: INDEX; Schema: api_umbrella; Owner: -
+--
+
+CREATE INDEX api_users_email_created_at_idx ON api_umbrella.api_users USING btree (email, created_at);
+
+
+--
 -- Name: api_users_roles_api_user_id_api_role_id_idx; Type: INDEX; Schema: api_umbrella; Owner: -
 --
 
@@ -2826,3 +2833,4 @@ INSERT INTO api_umbrella.lapis_migrations (name) VALUES ('1738353016');
 INSERT INTO api_umbrella.lapis_migrations (name) VALUES ('1753472899');
 INSERT INTO api_umbrella.lapis_migrations (name) VALUES ('1769633747');
 INSERT INTO api_umbrella.lapis_migrations (name) VALUES ('1769732670');
+INSERT INTO api_umbrella.lapis_migrations (name) VALUES ('1775265493');

--- a/src/migrations.lua
+++ b/src/migrations.lua
@@ -1586,4 +1586,10 @@ return {
     db.query(grants_sql)
     db.query("COMMIT")
   end,
+
+  [1775265493] = function()
+    db.query("CREATE INDEX CONCURRENTLY api_users_email_created_at_idx ON api_umbrella.api_users USING btree (email, created_at ASC)")
+
+    db.query(grants_sql)
+  end,
 }


### PR DESCRIPTION
When logging into the admin, if the api_users table was very large, performance could be poor for the admins on the initial login. It was due to this fetch of an API key based on the e-mail address that wasn't indexed:
https://github.com/NatLabRockies/api-umbrella/blob/bdda3929441a24e4aaa6fe114d8770985e0e76d5/src/api-umbrella/web-app/actions/admin/sessions.lua#L201

This adds an index to improve that query performance.

Fixes https://github.com/18F/api.data.gov/issues/701