### PR TITLE
fix bug where deleting an api backend returned an undefined error

### DIFF
--- a/src/api-umbrella/admin-ui/app/mixins/save.js
+++ b/src/api-umbrella/admin-ui/app/mixins/save.js
@@ -71,16 +71,17 @@ export default Mixin.create({
   destroyRecord(options) {
     bootbox.confirm(options.prompt, (result) => {
       if(result) {
-        this.model.destroyRecord().then(() => {
-          success({
-            title: 'Deleted',
-            text: (isFunction(options.message)) ? options.message(this.model) : options.message,
-            textTrusted: true,
+        const message = (isFunction(options.message)) ? options.message(this.model) : options.message;
+        this.router.transitionTo(options.transitionToRoute).then(() => {
+          this.model.destroyRecord().then(() => {
+            success({
+              title: 'Deleted',
+              text: message,
+              textTrusted: true,
+            });
+          }, function(response) {
+            bootbox.alert('Unexpected error deleting record: ' + response.responseText);
           });
-
-          this.router.transitionTo(options.transitionToRoute);
-        }, function(response) {
-          bootbox.alert('Unexpected error deleting record: ' + response.responseText);
         });
       }
     });

--- a/test/admin_ui/test_admin_groups.rb
+++ b/test/admin_ui/test_admin_groups.rb
@@ -71,4 +71,20 @@ class Test::AdminUi::TestAdminGroups < Minitest::Capybara::Test
       "backend_manage",
     ].sort, admin_group.permission_ids.sort)
   end
+
+  def test_delete_shows_success_notification_and_no_error
+    admin_group = FactoryBot.create(:admin_group, :name => "Delete Me Group")
+
+    admin_login
+    visit "/admin/#/admin_groups/#{admin_group.id}/edit"
+    assert_field("Group Name", :with => "Delete Me Group")
+
+    find("a.remove-action", :text => /Delete Admin Group/).click
+    click_button("OK")
+
+    assert_text("Successfully deleted")
+    refute_text("Unexpected error deleting record")
+
+    assert_nil(AdminGroup.where(:id => admin_group.id).first)
+  end
 end

--- a/test/admin_ui/test_apis.rb
+++ b/test/admin_ui/test_apis.rb
@@ -432,4 +432,24 @@ class Test::AdminUi::TestApis < Minitest::Capybara::Test
       assert_select("HTTP Method", :selected => "OPTIONS")
     end
   end
+
+  def test_delete_shows_success_notification_and_no_error
+    api = FactoryBot.create(:api_backend, :name => "Delete Me API")
+
+    admin_login
+    visit "/admin/#/apis/#{api.id}/edit"
+    assert_field("Name", :with => "Delete Me API")
+
+    # Click the "Delete API" link in the form, then confirm in the bootbox.
+    find("a.remove-action", :text => /Delete API/).click
+    click_button("OK")
+
+    # The success pnotify must appear...
+    assert_text("Successfully deleted")
+    # ...and the misleading error alert must NOT.
+    refute_text("Unexpected error deleting record")
+
+    # And the record must actually be gone.
+    assert_nil(ApiBackend.where(:id => api.id).first)
+  end
 end


### PR DESCRIPTION
resolves https://github.com/18F/api.data.gov/issues/703

What seemed to be happening was that ember kept trying to observe an api back end that had been deleted and no longer had data. This transitions away from that view first, so that it doesn't fall into that trap anymore. This does change the flow a bit, but It seemed a bit off to be still on the page for the back end you'd just deleted so this rectifies that.

I also added a couple tests to prove this out!