### PR TITLE
702 duplicate resources

### DIFF
--- a/src/api-umbrella/admin-ui/app/models/admin.js
+++ b/src/api-umbrella/admin-ui/app/models/admin.js
@@ -13,6 +13,7 @@ class Admin extends Model.extend(Validations) {
   static urlRoot = '/api-umbrella/v1/admins';
   static singlePayloadKey = 'admin';
   static arrayPayloadKey = 'data';
+  static duplicateExclude = ['username', 'email'];
 
   @attr()
   username;

--- a/src/api-umbrella/admin-ui/app/models/api-scope.js
+++ b/src/api-umbrella/admin-ui/app/models/api-scope.js
@@ -35,6 +35,7 @@ class ApiScope extends Model.extend(Validations) {
   static urlRoot = '/api-umbrella/v1/api_scopes';
   static singlePayloadKey = 'api_scope';
   static arrayPayloadKey = 'data';
+  static duplicateExclude = ['pathPrefix'];
 
   @attr()
   name;

--- a/src/api-umbrella/admin-ui/app/models/api-user.js
+++ b/src/api-umbrella/admin-ui/app/models/api-user.js
@@ -25,6 +25,7 @@ class ApiUser extends Model.extend(Validations) {
   static urlRoot = '/api-umbrella/v1/users';
   static singlePayloadKey = 'user';
   static arrayPayloadKey = 'data';
+  static duplicateExclude = ['apiKey', 'apiKeyHidesAt', 'apiKeyPreview', 'email', 'emailVerified'];
 
   @attr()
   apiKey;

--- a/src/api-umbrella/admin-ui/app/models/api-user.js
+++ b/src/api-umbrella/admin-ui/app/models/api-user.js
@@ -25,7 +25,7 @@ class ApiUser extends Model.extend(Validations) {
   static urlRoot = '/api-umbrella/v1/users';
   static singlePayloadKey = 'user';
   static arrayPayloadKey = 'data';
-  static duplicateExclude = ['apiKey', 'apiKeyHidesAt', 'apiKeyPreview', 'email', 'emailVerified'];
+  static duplicateExclude = ['apiKey', 'apiKeyHidesAt', 'apiKeyPreview', 'email', 'emailVerified', 'termsAndConditions', 'sendWelcomeEmail'];
 
   @attr()
   apiKey;

--- a/src/api-umbrella/admin-ui/app/models/api.js
+++ b/src/api-umbrella/admin-ui/app/models/api.js
@@ -112,12 +112,9 @@ class Api extends Model.extend(Validations) {
       this.set('settings', this.store.createRecord('api/settings'));
     }
 
-    // Force every embedded api/settings record (top-level + each sub_setting's
-    // own settings) to materialize now. Each settings record's own init/
-    // setDefaults runs the first time the record is accessed; if those firings
-    // are deferred until rendering, the model state changes mid-render and
-    // breaks Confirmation.isPageDirty (it sees a stable initial serialize that
-    // doesn't match a later serialize once setDefaults has fired).
+    // This can go away once we move from Ember Data's classic model layer
+    // to schema records/WarpDrive. We'd need to upgrade to
+    // ember data 5.x to do that kind of refactor.
     this.subSettings.forEach((subSetting) => {
       // Accessing the relationship is enough to materialize and fire init.
       // eslint-disable-next-line no-unused-expressions

--- a/src/api-umbrella/admin-ui/app/models/api.js
+++ b/src/api-umbrella/admin-ui/app/models/api.js
@@ -111,6 +111,18 @@ class Api extends Model.extend(Validations) {
     if(!this.settings) {
       this.set('settings', this.store.createRecord('api/settings'));
     }
+
+    // Force every embedded api/settings record (top-level + each sub_setting's
+    // own settings) to materialize now. Each settings record's own init/
+    // setDefaults runs the first time the record is accessed; if those firings
+    // are deferred until rendering, the model state changes mid-render and
+    // breaks Confirmation.isPageDirty (it sees a stable initial serialize that
+    // doesn't match a later serialize once setDefaults has fired).
+    this.subSettings.forEach((subSetting) => {
+      // Accessing the relationship is enough to materialize and fire init.
+      // eslint-disable-next-line no-unused-expressions
+      subSetting.settings;
+    });
   }
 
   get exampleIncomingUrlRoot() {

--- a/src/api-umbrella/admin-ui/app/routes/admin-groups/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/admin-groups/new.js
@@ -13,11 +13,11 @@ export default class NewRoute extends Form {
   };
 
   async model(params) {
-    clearStoreCache(this.store);
     let record;
     if (params.duplicate_id) {
       record = await this.duplicateRecord.cloneFromId('admin-group', params.duplicate_id);
     } else {
+      clearStoreCache(this.store);
       record = this.store.createRecord('admin-group');
     }
     return this.fetchModels(record);

--- a/src/api-umbrella/admin-ui/app/routes/admin-groups/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/admin-groups/new.js
@@ -1,36 +1,15 @@
-import { inject as service } from '@ember/service';
-import { success } from '@pnotify/core';
-import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
+import duplicableNewRoute from 'api-umbrella-admin-ui/utils/duplicable-new-route';
 
 import Form from './form';
 
-export default class NewRoute extends Form {
-  @service store;
-  @service duplicateRecord;
+export default class NewRoute extends duplicableNewRoute(Form) {
+  duplicateModelName = 'admin-group';
 
-  queryParams = {
-    duplicate_id: { refreshModel: true },
-  };
-
-  async model(params) {
-    let record;
-    if (params.duplicate_id) {
-      record = await this.duplicateRecord.cloneFromId('admin-group', params.duplicate_id);
-    } else {
-      clearStoreCache(this.store);
-      record = this.store.createRecord('admin-group');
-    }
+  wrapModel(record) {
     return this.fetchModels(record);
   }
 
-  afterModel(resolved) {
-    const record = resolved && resolved.record;
-    if (record && record._duplicatedFromName) {
-      success({
-        title: 'Duplicated',
-        text: `Duplicated from ${record._duplicatedFromName}`,
-      });
-      record._duplicatedFromName = null;
-    }
+  modelFromResolved(resolved) {
+    return resolved && resolved.record;
   }
 }

--- a/src/api-umbrella/admin-ui/app/routes/admin-groups/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/admin-groups/new.js
@@ -1,13 +1,36 @@
 import { inject as service } from '@ember/service';
+import { success } from '@pnotify/core';
 import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
 
 import Form from './form';
 
 export default class NewRoute extends Form {
   @service store;
+  @service duplicateRecord;
 
-  model() {
+  queryParams = {
+    duplicate_id: { refreshModel: true },
+  };
+
+  async model(params) {
     clearStoreCache(this.store);
-    return this.fetchModels(this.store.createRecord('admin-group'));
+    let record;
+    if (params.duplicate_id) {
+      record = await this.duplicateRecord.cloneFromId('admin-group', params.duplicate_id);
+    } else {
+      record = this.store.createRecord('admin-group');
+    }
+    return this.fetchModels(record);
+  }
+
+  afterModel(resolved) {
+    const record = resolved && resolved.record;
+    if (record && record._duplicatedFromName) {
+      success({
+        title: 'Duplicated',
+        text: `Duplicated from ${record._duplicatedFromName}`,
+      });
+      record._duplicatedFromName = null;
+    }
   }
 }

--- a/src/api-umbrella/admin-ui/app/routes/admins/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/admins/new.js
@@ -13,11 +13,11 @@ export default class NewRoute extends Form {
   };
 
   async model(params) {
-    clearStoreCache(this.store);
     let record;
     if (params.duplicate_id) {
       record = await this.duplicateRecord.cloneFromId('admin', params.duplicate_id);
     } else {
+      clearStoreCache(this.store);
       record = this.store.createRecord('admin', { sendInviteEmail: true });
     }
     return this.fetchModels(record);

--- a/src/api-umbrella/admin-ui/app/routes/admins/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/admins/new.js
@@ -1,13 +1,36 @@
 import { inject as service } from '@ember/service';
+import { success } from '@pnotify/core';
 import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
 
 import Form from './form';
 
 export default class NewRoute extends Form {
   @service store;
+  @service duplicateRecord;
 
-  model() {
+  queryParams = {
+    duplicate_id: { refreshModel: true },
+  };
+
+  async model(params) {
     clearStoreCache(this.store);
-    return this.fetchModels(this.store.createRecord('admin', { sendInviteEmail: true }));
+    let record;
+    if (params.duplicate_id) {
+      record = await this.duplicateRecord.cloneFromId('admin', params.duplicate_id);
+    } else {
+      record = this.store.createRecord('admin', { sendInviteEmail: true });
+    }
+    return this.fetchModels(record);
+  }
+
+  afterModel(resolved) {
+    const record = resolved && resolved.record;
+    if (record && record._duplicatedFromName) {
+      success({
+        title: 'Duplicated',
+        text: `Duplicated from ${record._duplicatedFromName}`,
+      });
+      record._duplicatedFromName = null;
+    }
   }
 }

--- a/src/api-umbrella/admin-ui/app/routes/admins/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/admins/new.js
@@ -1,36 +1,19 @@
-import { inject as service } from '@ember/service';
-import { success } from '@pnotify/core';
-import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
+import duplicableNewRoute from 'api-umbrella-admin-ui/utils/duplicable-new-route';
 
 import Form from './form';
 
-export default class NewRoute extends Form {
-  @service store;
-  @service duplicateRecord;
+export default class NewRoute extends duplicableNewRoute(Form) {
+  duplicateModelName = 'admin';
 
-  queryParams = {
-    duplicate_id: { refreshModel: true },
-  };
+  newRecordAttrs() {
+    return { sendInviteEmail: true };
+  }
 
-  async model(params) {
-    let record;
-    if (params.duplicate_id) {
-      record = await this.duplicateRecord.cloneFromId('admin', params.duplicate_id);
-    } else {
-      clearStoreCache(this.store);
-      record = this.store.createRecord('admin', { sendInviteEmail: true });
-    }
+  wrapModel(record) {
     return this.fetchModels(record);
   }
 
-  afterModel(resolved) {
-    const record = resolved && resolved.record;
-    if (record && record._duplicatedFromName) {
-      success({
-        title: 'Duplicated',
-        text: `Duplicated from ${record._duplicatedFromName}`,
-      });
-      record._duplicatedFromName = null;
-    }
+  modelFromResolved(resolved) {
+    return resolved && resolved.record;
   }
 }

--- a/src/api-umbrella/admin-ui/app/routes/api-scopes/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/api-scopes/new.js
@@ -13,11 +13,11 @@ export default class NewRoute extends Form {
   };
 
   async model(params) {
-    clearStoreCache(this.store);
     let record;
     if (params.duplicate_id) {
       record = await this.duplicateRecord.cloneFromId('api-scope', params.duplicate_id);
     } else {
+      clearStoreCache(this.store);
       record = this.store.createRecord('api-scope');
     }
     return record;

--- a/src/api-umbrella/admin-ui/app/routes/api-scopes/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/api-scopes/new.js
@@ -1,13 +1,36 @@
 import { inject as service } from '@ember/service';
+import { success } from '@pnotify/core';
 import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
 
 import Form from './form';
 
 export default class NewRoute extends Form {
   @service store;
+  @service duplicateRecord;
 
-  model() {
+  queryParams = {
+    duplicate_id: { refreshModel: true },
+  };
+
+  async model(params) {
     clearStoreCache(this.store);
-    return this.store.createRecord('api-scope');
+    let record;
+    if (params.duplicate_id) {
+      record = await this.duplicateRecord.cloneFromId('api-scope', params.duplicate_id);
+    } else {
+      record = this.store.createRecord('api-scope');
+    }
+    return record;
+  }
+
+  afterModel(resolved) {
+    const record = resolved;
+    if (record && record._duplicatedFromName) {
+      success({
+        title: 'Duplicated',
+        text: `Duplicated from ${record._duplicatedFromName}`,
+      });
+      record._duplicatedFromName = null;
+    }
   }
 }

--- a/src/api-umbrella/admin-ui/app/routes/api-scopes/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/api-scopes/new.js
@@ -1,36 +1,7 @@
-import { inject as service } from '@ember/service';
-import { success } from '@pnotify/core';
-import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
+import duplicableNewRoute from 'api-umbrella-admin-ui/utils/duplicable-new-route';
 
 import Form from './form';
 
-export default class NewRoute extends Form {
-  @service store;
-  @service duplicateRecord;
-
-  queryParams = {
-    duplicate_id: { refreshModel: true },
-  };
-
-  async model(params) {
-    let record;
-    if (params.duplicate_id) {
-      record = await this.duplicateRecord.cloneFromId('api-scope', params.duplicate_id);
-    } else {
-      clearStoreCache(this.store);
-      record = this.store.createRecord('api-scope');
-    }
-    return record;
-  }
-
-  afterModel(resolved) {
-    const record = resolved;
-    if (record && record._duplicatedFromName) {
-      success({
-        title: 'Duplicated',
-        text: `Duplicated from ${record._duplicatedFromName}`,
-      });
-      record._duplicatedFromName = null;
-    }
-  }
+export default class NewRoute extends duplicableNewRoute(Form) {
+  duplicateModelName = 'api-scope';
 }

--- a/src/api-umbrella/admin-ui/app/routes/api-users/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/api-users/new.js
@@ -1,36 +1,15 @@
-import { inject as service } from '@ember/service';
-import { success } from '@pnotify/core';
-import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
+import duplicableNewRoute from 'api-umbrella-admin-ui/utils/duplicable-new-route';
 
 import Form from './form';
 
-export default class NewRoute extends Form {
-  @service store;
-  @service duplicateRecord;
+export default class NewRoute extends duplicableNewRoute(Form) {
+  duplicateModelName = 'api-user';
 
-  queryParams = {
-    duplicate_id: { refreshModel: true },
-  };
-
-  async model(params) {
-    let record;
-    if (params.duplicate_id) {
-      record = await this.duplicateRecord.cloneFromId('api-user', params.duplicate_id);
-    } else {
-      clearStoreCache(this.store);
-      record = this.store.createRecord('api-user');
-    }
+  wrapModel(record) {
     return this.fetchModels(record);
   }
 
-  afterModel(resolved) {
-    const record = resolved && resolved.record;
-    if (record && record._duplicatedFromName) {
-      success({
-        title: 'Duplicated',
-        text: `Duplicated from ${record._duplicatedFromName}`,
-      });
-      record._duplicatedFromName = null;
-    }
+  modelFromResolved(resolved) {
+    return resolved && resolved.record;
   }
 }

--- a/src/api-umbrella/admin-ui/app/routes/api-users/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/api-users/new.js
@@ -1,13 +1,36 @@
 import { inject as service } from '@ember/service';
+import { success } from '@pnotify/core';
 import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
 
 import Form from './form';
 
 export default class NewRoute extends Form {
   @service store;
+  @service duplicateRecord;
 
-  model() {
+  queryParams = {
+    duplicate_id: { refreshModel: true },
+  };
+
+  async model(params) {
     clearStoreCache(this.store);
-    return this.fetchModels(this.store.createRecord('api-user'));
+    let record;
+    if (params.duplicate_id) {
+      record = await this.duplicateRecord.cloneFromId('api-user', params.duplicate_id);
+    } else {
+      record = this.store.createRecord('api-user');
+    }
+    return this.fetchModels(record);
+  }
+
+  afterModel(resolved) {
+    const record = resolved && resolved.record;
+    if (record && record._duplicatedFromName) {
+      success({
+        title: 'Duplicated',
+        text: `Duplicated from ${record._duplicatedFromName}`,
+      });
+      record._duplicatedFromName = null;
+    }
   }
 }

--- a/src/api-umbrella/admin-ui/app/routes/api-users/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/api-users/new.js
@@ -13,11 +13,11 @@ export default class NewRoute extends Form {
   };
 
   async model(params) {
-    clearStoreCache(this.store);
     let record;
     if (params.duplicate_id) {
       record = await this.duplicateRecord.cloneFromId('api-user', params.duplicate_id);
     } else {
+      clearStoreCache(this.store);
       record = this.store.createRecord('api-user');
     }
     return this.fetchModels(record);

--- a/src/api-umbrella/admin-ui/app/routes/apis/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/apis/new.js
@@ -1,15 +1,38 @@
 import { inject as service } from '@ember/service';
+import { success } from '@pnotify/core';
 import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
 
 import Form from './form';
 
 export default class NewRoute extends Form {
   @service store;
+  @service duplicateRecord;
 
-  model() {
+  queryParams = {
+    duplicate_id: { refreshModel: true },
+  };
+
+  async model(params) {
     clearStoreCache(this.store);
-    return this.fetchModels(this.store.createRecord('api', {
-      frontendHost: location.hostname,
-    }));
+    let record;
+    if (params.duplicate_id) {
+      record = await this.duplicateRecord.cloneFromId('api', params.duplicate_id);
+    } else {
+      record = this.store.createRecord('api', {
+        frontendHost: location.hostname,
+      });
+    }
+    return this.fetchModels(record);
+  }
+
+  afterModel(resolved) {
+    const record = resolved && resolved.record;
+    if (record && record._duplicatedFromName) {
+      success({
+        title: 'Duplicated',
+        text: `Duplicated from ${record._duplicatedFromName}`,
+      });
+      record._duplicatedFromName = null;
+    }
   }
 }

--- a/src/api-umbrella/admin-ui/app/routes/apis/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/apis/new.js
@@ -13,11 +13,11 @@ export default class NewRoute extends Form {
   };
 
   async model(params) {
-    clearStoreCache(this.store);
     let record;
     if (params.duplicate_id) {
       record = await this.duplicateRecord.cloneFromId('api', params.duplicate_id);
     } else {
+      clearStoreCache(this.store);
       record = this.store.createRecord('api', {
         frontendHost: location.hostname,
       });

--- a/src/api-umbrella/admin-ui/app/routes/apis/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/apis/new.js
@@ -1,38 +1,19 @@
-import { inject as service } from '@ember/service';
-import { success } from '@pnotify/core';
-import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
+import duplicableNewRoute from 'api-umbrella-admin-ui/utils/duplicable-new-route';
 
 import Form from './form';
 
-export default class NewRoute extends Form {
-  @service store;
-  @service duplicateRecord;
+export default class NewRoute extends duplicableNewRoute(Form) {
+  duplicateModelName = 'api';
 
-  queryParams = {
-    duplicate_id: { refreshModel: true },
-  };
+  newRecordAttrs() {
+    return { frontendHost: location.hostname };
+  }
 
-  async model(params) {
-    let record;
-    if (params.duplicate_id) {
-      record = await this.duplicateRecord.cloneFromId('api', params.duplicate_id);
-    } else {
-      clearStoreCache(this.store);
-      record = this.store.createRecord('api', {
-        frontendHost: location.hostname,
-      });
-    }
+  wrapModel(record) {
     return this.fetchModels(record);
   }
 
-  afterModel(resolved) {
-    const record = resolved && resolved.record;
-    if (record && record._duplicatedFromName) {
-      success({
-        title: 'Duplicated',
-        text: `Duplicated from ${record._duplicatedFromName}`,
-      });
-      record._duplicatedFromName = null;
-    }
+  modelFromResolved(resolved) {
+    return resolved && resolved.record;
   }
 }

--- a/src/api-umbrella/admin-ui/app/routes/website-backends/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/website-backends/new.js
@@ -1,15 +1,36 @@
 import { inject as service } from '@ember/service';
+import { success } from '@pnotify/core';
 import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
 
 import Form from './form';
 
 export default class NewRoute extends Form {
   @service store;
+  @service duplicateRecord;
 
-  model() {
+  queryParams = {
+    duplicate_id: { refreshModel: true },
+  };
+
+  async model(params) {
     clearStoreCache(this.store);
-    return this.store.createRecord('website-backend', {
-      serverPort: 80,
-    });
+    let record;
+    if (params.duplicate_id) {
+      record = await this.duplicateRecord.cloneFromId('website-backend', params.duplicate_id);
+    } else {
+      record = this.store.createRecord('website-backend', { serverPort: 80 });
+    }
+    return record;
+  }
+
+  afterModel(resolved) {
+    const record = resolved;
+    if (record && record._duplicatedFromName) {
+      success({
+        title: 'Duplicated',
+        text: `Duplicated from ${record._duplicatedFromName}`,
+      });
+      record._duplicatedFromName = null;
+    }
   }
 }

--- a/src/api-umbrella/admin-ui/app/routes/website-backends/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/website-backends/new.js
@@ -13,11 +13,11 @@ export default class NewRoute extends Form {
   };
 
   async model(params) {
-    clearStoreCache(this.store);
     let record;
     if (params.duplicate_id) {
       record = await this.duplicateRecord.cloneFromId('website-backend', params.duplicate_id);
     } else {
+      clearStoreCache(this.store);
       record = this.store.createRecord('website-backend', { serverPort: 80 });
     }
     return record;

--- a/src/api-umbrella/admin-ui/app/routes/website-backends/new.js
+++ b/src/api-umbrella/admin-ui/app/routes/website-backends/new.js
@@ -1,36 +1,11 @@
-import { inject as service } from '@ember/service';
-import { success } from '@pnotify/core';
-import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
+import duplicableNewRoute from 'api-umbrella-admin-ui/utils/duplicable-new-route';
 
 import Form from './form';
 
-export default class NewRoute extends Form {
-  @service store;
-  @service duplicateRecord;
+export default class NewRoute extends duplicableNewRoute(Form) {
+  duplicateModelName = 'website-backend';
 
-  queryParams = {
-    duplicate_id: { refreshModel: true },
-  };
-
-  async model(params) {
-    let record;
-    if (params.duplicate_id) {
-      record = await this.duplicateRecord.cloneFromId('website-backend', params.duplicate_id);
-    } else {
-      clearStoreCache(this.store);
-      record = this.store.createRecord('website-backend', { serverPort: 80 });
-    }
-    return record;
-  }
-
-  afterModel(resolved) {
-    const record = resolved;
-    if (record && record._duplicatedFromName) {
-      success({
-        title: 'Duplicated',
-        text: `Duplicated from ${record._duplicatedFromName}`,
-      });
-      record._duplicatedFromName = null;
-    }
+  newRecordAttrs() {
+    return { serverPort: 80 };
   }
 }

--- a/src/api-umbrella/admin-ui/app/services/duplicate-record.js
+++ b/src/api-umbrella/admin-ui/app/services/duplicate-record.js
@@ -1,0 +1,57 @@
+import Service, { inject as service } from '@ember/service';
+import cloneDeep from 'lodash-es/cloneDeep';
+
+const UNIVERSAL_EXCLUDE = ['id', 'createdAt', 'updatedAt', 'creator', 'updater'];
+
+export default class DuplicateRecordService extends Service {
+  @service store;
+
+  async cloneFromId(modelName, sourceId) {
+    const source = await this.store.findRecord(modelName, sourceId, { reload: true });
+    const clone = this._cloneRecord(modelName, source);
+    clone._duplicatedFromName = source.name || source.email || 'record';
+    return clone;
+  }
+
+  _cloneRecord(modelName, source) {
+    const modelClass = this.store.modelFor(modelName);
+    const exclude = new Set([
+      ...UNIVERSAL_EXCLUDE,
+      ...(modelClass.duplicateExclude || []),
+    ]);
+
+    const attrs = {};
+
+    modelClass.eachAttribute((name) => {
+      if (exclude.has(name)) {
+        return;
+      }
+      const value = source.get(name);
+      attrs[name] = this._isPlainStructure(value) ? cloneDeep(value) : value;
+    });
+
+    modelClass.eachRelationship((name, descriptor) => {
+      if (exclude.has(name)) {
+        return;
+      }
+      const related = source.get(name);
+      if (descriptor.kind === 'belongsTo') {
+        attrs[name] = related ? this._cloneRecord(descriptor.type, related) : null;
+      } else if (descriptor.kind === 'hasMany') {
+        attrs[name] = (related || []).map((child) => this._cloneRecord(descriptor.type, child));
+      }
+    });
+
+    return this.store.createRecord(modelName, attrs);
+  }
+
+  _isPlainStructure(value) {
+    if (value === null || value === undefined) {
+      return false;
+    }
+    if (Array.isArray(value)) {
+      return true;
+    }
+    return typeof value === 'object' && value.constructor === Object;
+  }
+}

--- a/src/api-umbrella/admin-ui/app/services/duplicate-record.js
+++ b/src/api-umbrella/admin-ui/app/services/duplicate-record.js
@@ -23,7 +23,7 @@ export default class DuplicateRecordService extends Service {
     const attrs = {};
 
     modelClass.eachAttribute((name) => {
-      if (exclude.has(name)) {
+      if(exclude.has(name)) {
         return;
       }
       const value = source.get(name);
@@ -31,13 +31,13 @@ export default class DuplicateRecordService extends Service {
     });
 
     modelClass.eachRelationship((name, descriptor) => {
-      if (exclude.has(name)) {
+      if(exclude.has(name)) {
         return;
       }
       const related = source.get(name);
-      if (descriptor.kind === 'belongsTo') {
+      if(descriptor.kind === 'belongsTo') {
         attrs[name] = related ? this._cloneRecord(descriptor.type, related) : null;
-      } else if (descriptor.kind === 'hasMany') {
+      } else if(descriptor.kind === 'hasMany') {
         attrs[name] = (related || []).map((child) => this._cloneRecord(descriptor.type, child));
       }
     });
@@ -46,10 +46,10 @@ export default class DuplicateRecordService extends Service {
   }
 
   _isPlainStructure(value) {
-    if (value === null || value === undefined) {
+    if(value === null || value === undefined) {
       return false;
     }
-    if (Array.isArray(value)) {
+    if(Array.isArray(value)) {
       return true;
     }
     return typeof value === 'object' && value.constructor === Object;

--- a/src/api-umbrella/admin-ui/app/styles/_forms.scss
+++ b/src/api-umbrella/admin-ui/app/styles/_forms.scss
@@ -119,6 +119,10 @@ fieldset .table {
 
 .form-extra-actions {
   margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
 }
 
 .custom-control.custom-control-no-label {

--- a/src/api-umbrella/admin-ui/app/templates/components/admin-groups/record-form.hbs
+++ b/src/api-umbrella/admin-ui/app/templates/components/admin-groups/record-form.hbs
@@ -43,6 +43,7 @@
       {{#if this.model.id}}
         {{#unless this.isDisabled}}
           <div class="form-extra-actions">
+            <LinkTo @route="admin-groups.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate Admin Group</LinkTo>
             <a href="#" class="remove-action" {{action "delete"}}><FaIcon @icon="times" />Delete Admin Group</a>
           </div>
         {{/unless}}

--- a/src/api-umbrella/admin-ui/app/templates/components/admin-groups/record-form.hbs
+++ b/src/api-umbrella/admin-ui/app/templates/components/admin-groups/record-form.hbs
@@ -43,7 +43,7 @@
       {{#if this.model.id}}
         {{#unless this.isDisabled}}
           <div class="form-extra-actions">
-            <LinkTo @route="admin-groups.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate Admin Group</LinkTo>
+            <LinkTo @route="admin_groups.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate Admin Group</LinkTo>
             <a href="#" class="remove-action" {{action "delete"}}><FaIcon @icon="times" />Delete Admin Group</a>
           </div>
         {{/unless}}

--- a/src/api-umbrella/admin-ui/app/templates/components/admins/record-form.hbs
+++ b/src/api-umbrella/admin-ui/app/templates/components/admins/record-form.hbs
@@ -87,6 +87,7 @@
       {{#if this.currentAdmin.permissions.admin_manage}}
         {{#if this.model.id}}
           <div class="form-extra-actions">
+            <LinkTo @route="admins.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate Admin</LinkTo>
             <a href="#" class="remove-action" {{action "delete"}}><FaIcon @icon="times" />Delete Admin</a>
           </div>
         {{/if}}

--- a/src/api-umbrella/admin-ui/app/templates/components/api-scopes/record-form.hbs
+++ b/src/api-umbrella/admin-ui/app/templates/components/api-scopes/record-form.hbs
@@ -57,7 +57,7 @@
       {{#if this.model.id}}
         {{#unless this.isDisabled}}
           <div class="form-extra-actions">
-            <LinkTo @route="api-scopes.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate API Scope</LinkTo>
+            <LinkTo @route="api_scopes.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate API Scope</LinkTo>
             <a href="#" class="remove-action" {{action "delete"}}><FaIcon @icon="times" />Delete API Scope</a>
           </div>
         {{/unless}}

--- a/src/api-umbrella/admin-ui/app/templates/components/api-scopes/record-form.hbs
+++ b/src/api-umbrella/admin-ui/app/templates/components/api-scopes/record-form.hbs
@@ -57,6 +57,7 @@
       {{#if this.model.id}}
         {{#unless this.isDisabled}}
           <div class="form-extra-actions">
+            <LinkTo @route="api-scopes.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate API Scope</LinkTo>
             <a href="#" class="remove-action" {{action "delete"}}><FaIcon @icon="times" />Delete API Scope</a>
           </div>
         {{/unless}}

--- a/src/api-umbrella/admin-ui/app/templates/components/api-users/record-form.hbs
+++ b/src/api-umbrella/admin-ui/app/templates/components/api-users/record-form.hbs
@@ -78,7 +78,7 @@
     </FieldsFor>
     {{#if this.model.id}}
       <div class="form-extra-actions">
-        <LinkTo @route="api-users.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate API User</LinkTo>
+        <LinkTo @route="api_users.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate API User</LinkTo>
       </div>
     {{/if}}
   </form>

--- a/src/api-umbrella/admin-ui/app/templates/components/api-users/record-form.hbs
+++ b/src/api-umbrella/admin-ui/app/templates/components/api-users/record-form.hbs
@@ -76,5 +76,10 @@
         </div>
       </div>
     </FieldsFor>
+    {{#if this.model.id}}
+      <div class="form-extra-actions">
+        <LinkTo @route="api-users.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate API User</LinkTo>
+      </div>
+    {{/if}}
   </form>
 </div>

--- a/src/api-umbrella/admin-ui/app/templates/components/apis/record-form.hbs
+++ b/src/api-umbrella/admin-ui/app/templates/components/apis/record-form.hbs
@@ -151,6 +151,7 @@
     </div>
     {{#if this.model.id}}
       <div class="form-extra-actions">
+        <LinkTo @route="apis.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate API</LinkTo>
         <a href="#" class="remove-action" {{action "delete"}}><FaIcon @icon="times" />Delete API</a>
       </div>
     {{/if}}

--- a/src/api-umbrella/admin-ui/app/templates/components/website-backends/record-form.hbs
+++ b/src/api-umbrella/admin-ui/app/templates/components/website-backends/record-form.hbs
@@ -23,7 +23,7 @@
       </div>
       {{#if this.model.id}}
         <div class="form-extra-actions">
-          <LinkTo @route="website-backends.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate Website Backend</LinkTo>
+          <LinkTo @route="website_backends.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate Website Backend</LinkTo>
           <a href="#" class="remove-action" {{action "delete"}}><FaIcon @icon="times" />Delete Website Backend</a>
         </div>
       {{/if}}

--- a/src/api-umbrella/admin-ui/app/templates/components/website-backends/record-form.hbs
+++ b/src/api-umbrella/admin-ui/app/templates/components/website-backends/record-form.hbs
@@ -23,6 +23,7 @@
       </div>
       {{#if this.model.id}}
         <div class="form-extra-actions">
+          <LinkTo @route="website-backends.new" @query={{hash duplicate_id=this.model.id}} class="duplicate-action"><FaIcon @icon="copy" />Duplicate Website Backend</LinkTo>
           <a href="#" class="remove-action" {{action "delete"}}><FaIcon @icon="times" />Delete Website Backend</a>
         </div>
       {{/if}}

--- a/src/api-umbrella/admin-ui/app/utils/duplicable-new-route.js
+++ b/src/api-umbrella/admin-ui/app/utils/duplicable-new-route.js
@@ -1,0 +1,64 @@
+import { inject as service } from '@ember/service';
+import { success } from '@pnotify/core';
+import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
+
+// Returns a route class that adds support for cloning a source record
+// when `duplicate_id` is present in the query string. Each new-route in
+// the admin UI extends `duplicableNewRoute(Form)` instead of `Form`
+// directly, so this class sits between Form and the resource's NewRoute.
+//
+// Subclasses must declare `duplicateModelName` (the Ember Data model
+// name). They may override:
+//   - `newRecordAttrs()` to provide createRecord defaults on the
+//     non-duplicate path (default: `{}`).
+//   - `wrapModel(record)` to wrap the resolved record in a hash via
+//     `this.fetchModels(record)` for resources whose form route loads
+//     auxiliary data alongside the record (default: identity).
+//   - `modelFromResolved(resolved)` to extract the record from the hash
+//     in `afterModel` (default: identity, matching `wrapModel: identity`).
+export default function duplicableNewRoute(SuperClass) {
+  return class DuplicableNewRoute extends SuperClass {
+    @service store;
+    @service duplicateRecord;
+
+    queryParams = {
+      duplicate_id: { refreshModel: true },
+    };
+
+    duplicateModelName = null;
+
+    newRecordAttrs() {
+      return {};
+    }
+
+    wrapModel(record) {
+      return record;
+    }
+
+    modelFromResolved(resolved) {
+      return resolved;
+    }
+
+    async model(params) {
+      let record;
+      if (params.duplicate_id) {
+        record = await this.duplicateRecord.cloneFromId(this.duplicateModelName, params.duplicate_id);
+      } else {
+        clearStoreCache(this.store);
+        record = this.store.createRecord(this.duplicateModelName, this.newRecordAttrs());
+      }
+      return this.wrapModel(record);
+    }
+
+    afterModel(resolved) {
+      const record = this.modelFromResolved(resolved);
+      if (record && record._duplicatedFromName) {
+        success({
+          title: 'Duplicated',
+          text: `Duplicated from ${record._duplicatedFromName}`,
+        });
+        record._duplicatedFromName = null;
+      }
+    }
+  };
+}

--- a/src/api-umbrella/admin-ui/app/utils/duplicable-new-route.js
+++ b/src/api-umbrella/admin-ui/app/utils/duplicable-new-route.js
@@ -3,7 +3,7 @@ import { success } from '@pnotify/core';
 import { clearStoreCache } from 'api-umbrella-admin-ui/utils/uncached-model';
 
 // Returns a route class that adds support for cloning a source record
-// when `duplicate_id` is present in the query string. Each new-route in
+// when `duplicate_id` is present in the query string. Each new route in
 // the admin UI extends `duplicableNewRoute(Form)` instead of `Form`
 // directly, so this class sits between Form and the resource's NewRoute.
 //

--- a/src/api-umbrella/admin-ui/app/utils/duplicable-new-route.js
+++ b/src/api-umbrella/admin-ui/app/utils/duplicable-new-route.js
@@ -41,7 +41,7 @@ export default function duplicableNewRoute(SuperClass) {
 
     async model(params) {
       let record;
-      if (params.duplicate_id) {
+      if(params.duplicate_id) {
         record = await this.duplicateRecord.cloneFromId(this.duplicateModelName, params.duplicate_id);
       } else {
         clearStoreCache(this.store);
@@ -52,7 +52,7 @@ export default function duplicableNewRoute(SuperClass) {
 
     afterModel(resolved) {
       const record = this.modelFromResolved(resolved);
-      if (record && record._duplicatedFromName) {
+      if(record && record._duplicatedFromName) {
         success({
           title: 'Duplicated',
           text: `Duplicated from ${record._duplicatedFromName}`,

--- a/src/api-umbrella/admin-ui/config/icons.js
+++ b/src/api-umbrella/admin-ui/config/icons.js
@@ -7,6 +7,7 @@ module.exports = function() {
       'calendar',
       'caret-down',
       'cog',
+      'copy',
       'lock',
       'map-marker-alt',
       'pencil-alt',

--- a/test/admin_ui/test_admin_groups.rb
+++ b/test/admin_ui/test_admin_groups.rb
@@ -104,4 +104,11 @@ class Test::AdminUi::TestAdminGroups < Minitest::Capybara::Test
     assert_equal("Source Group For Duplicate", source.name, "source name unchanged")
     assert_equal(source_api_scope_ids, source.api_scope_ids.sort, "source scopes unchanged")
   end
+
+  def test_duplicate_link_hidden_on_new_form
+    admin_login
+    visit "/admin/#/admin_groups/new"
+    assert_field("Group Name")
+    refute_selector("a.duplicate-action")
+  end
 end

--- a/test/admin_ui/test_admin_groups.rb
+++ b/test/admin_ui/test_admin_groups.rb
@@ -71,4 +71,37 @@ class Test::AdminUi::TestAdminGroups < Minitest::Capybara::Test
       "backend_manage",
     ].sort, admin_group.permission_ids.sort)
   end
+
+  def test_duplicate_creates_new_record_with_copied_data
+    api_scope = FactoryBot.create(:api_scope, :name => "Scope For Duplicate")
+    source = FactoryBot.create(:admin_group, :name => "Source Group For Duplicate", :api_scopes => [api_scope])
+    source_id = source.id
+    source_api_scope_ids = source.api_scope_ids.sort
+    source_permission_ids = source.permission_ids.sort
+
+    admin_login
+    visit "/admin/#/admin_groups/#{source.id}/edit"
+    assert_field("Group Name", :with => "Source Group For Duplicate")
+
+    find("a.duplicate-action", :text => /Duplicate Admin Group/).click
+
+    assert_current_path %r{/admin/#/admin_groups/new\?duplicate_id=#{source.id}}, :url => true
+    assert_text("Duplicated from Source Group For Duplicate")
+    assert_field("Group Name", :with => "Source Group For Duplicate")
+    assert_checked_field("Scope For Duplicate", :visible => :all)
+
+    fill_in("Group Name", :with => "Duplicate Group For Duplicate")
+    click_button("Save")
+    assert_text("Successfully saved")
+
+    duplicate = AdminGroup.where(:name => "Duplicate Group For Duplicate").order(:created_at => :desc).first
+    refute_nil(duplicate, "duplicate group was created")
+    refute_equal(source_id, duplicate.id, "duplicate has fresh id")
+    assert_equal(source_api_scope_ids, duplicate.api_scope_ids.sort, "duplicate references same scopes as source")
+    assert_equal(source_permission_ids, duplicate.permission_ids.sort, "duplicate references same permissions as source")
+
+    source.reload
+    assert_equal("Source Group For Duplicate", source.name, "source name unchanged")
+    assert_equal(source_api_scope_ids, source.api_scope_ids.sort, "source scopes unchanged")
+  end
 end

--- a/test/admin_ui/test_admins.rb
+++ b/test/admin_ui/test_admins.rb
@@ -99,4 +99,45 @@ class Test::AdminUi::TestAdmins < Minitest::Capybara::Test
     assert_text(admin.authentication_token)
     refute_button("Save")
   end
+
+  def test_duplicate_creates_new_record_with_email_cleared
+    group = FactoryBot.create(:admin_group, :name => "Group For Duplicate")
+    source = FactoryBot.create(:limited_admin, :username => "source.admin@example.com", :groups => [group])
+    source_id = source.id
+    source_username = source.username
+    source_email = source.email
+    source_group_ids = source.group_ids.sort
+
+    admin_login
+    visit "/admin/#/admins/#{source.id}/edit"
+    assert_field("Email", :with => "source.admin@example.com")
+
+    find("a.duplicate-action", :text => /Duplicate Admin/).click
+
+    assert_current_path %r{/admin/#/admins/new\?duplicate_id=#{source.id}}, :url => true
+    assert_text("Duplicated from")
+    assert_field("Email", :with => "")
+
+    fill_in("Email", :with => "duplicate.admin@example.com")
+    click_button("Save")
+    assert_text("Successfully saved the admin")
+
+    duplicate = Admin.where(:username => "duplicate.admin@example.com").order(:created_at => :desc).first
+    refute_nil(duplicate, "duplicate admin was created")
+    refute_equal(source_id, duplicate.id, "duplicate has fresh id")
+    refute_equal(source_username, duplicate.username, "duplicate has fresh username")
+    refute_equal(source_email, duplicate.email, "duplicate has fresh email")
+    assert_equal(source_group_ids, duplicate.group_ids.sort, "duplicate references same groups as source")
+
+    source.reload
+    assert_equal(source_username, source.username, "source username unchanged")
+    assert_equal(source_email, source.email, "source email unchanged")
+  end
+
+  def test_duplicate_link_hidden_on_new_form
+    admin_login
+    visit "/admin/#/admins/new"
+    assert_text("Email")
+    refute_selector("a.duplicate-action")
+  end
 end

--- a/test/admin_ui/test_api_scopes.rb
+++ b/test/admin_ui/test_api_scopes.rb
@@ -49,4 +49,45 @@ class Test::AdminUi::TestApiScopes < Minitest::Capybara::Test
     assert_equal("2.example.com", api_scope.host)
     assert_equal("/2/", api_scope.path_prefix)
   end
+
+  def test_duplicate_creates_new_record_with_path_prefix_cleared
+    source = FactoryBot.create(:api_scope, :name => "Source Scope For Duplicate", :host => "source.example.com", :path_prefix => "/source/")
+    source_id = source.id
+    source_host = source.host
+    source_path_prefix = source.path_prefix
+
+    admin_login
+    visit "/admin/#/api_scopes/#{source.id}/edit"
+    assert_field("Name", :with => "Source Scope For Duplicate")
+
+    find("a.duplicate-action", :text => /Duplicate API Scope/).click
+
+    assert_current_path %r{/admin/#/api_scopes/new\?duplicate_id=#{source.id}}, :url => true
+    assert_text("Duplicated from Source Scope For Duplicate")
+    assert_field("Name", :with => "Source Scope For Duplicate")
+    assert_field("Host", :with => "source.example.com")
+    assert_field("Path Prefix", :with => "")
+
+    fill_in("Name", :with => "Duplicate Scope For Duplicate")
+    fill_in("Path Prefix", :with => "/duplicate/")
+    click_button("Save")
+    assert_text("Successfully saved")
+
+    duplicate = ApiScope.where(:name => "Duplicate Scope For Duplicate").order(:created_at => :desc).first
+    refute_nil(duplicate, "duplicate scope was created")
+    refute_equal(source_id, duplicate.id, "duplicate has fresh id")
+    assert_equal(source_host, duplicate.host, "host preserved")
+    assert_equal("/duplicate/", duplicate.path_prefix, "duplicate has new path_prefix")
+
+    source.reload
+    assert_equal("Source Scope For Duplicate", source.name, "source name unchanged")
+    assert_equal(source_path_prefix, source.path_prefix, "source path_prefix unchanged")
+  end
+
+  def test_duplicate_link_hidden_on_new_form
+    admin_login
+    visit "/admin/#/api_scopes/new"
+    assert_field("Name")
+    refute_selector("a.duplicate-action")
+  end
 end

--- a/test/admin_ui/test_api_users.rb
+++ b/test/admin_ui/test_api_users.rb
@@ -127,4 +127,11 @@ class Test::AdminUi::TestApiUsers < Minitest::Capybara::Test
     assert_equal(source_email, source.email, "source email unchanged")
     assert_equal(source_api_key, source.api_key, "source api_key unchanged")
   end
+
+  def test_duplicate_link_hidden_on_new_form
+    admin_login
+    visit "/admin/#/api_users/new"
+    assert_field("E-mail")
+    refute_selector("a.duplicate-action")
+  end
 end

--- a/test/admin_ui/test_api_users.rb
+++ b/test/admin_ui/test_api_users.rb
@@ -80,4 +80,51 @@ class Test::AdminUi::TestApiUsers < Minitest::Capybara::Test
     assert_text("Created: 2015-01-15 11:06 PM MST by ")
     assert_text("Last Updated: 2015-07-16 12:09 AM MDT by ")
   end
+
+  def test_duplicate_creates_new_record_with_email_cleared
+    source = FactoryBot.create(:api_user, :first_name => "Source", :last_name => "User", :email => "source.user@example.com", :use_description => "Some description")
+    source_id = source.id
+    source_email = source.email
+    source_api_key = source.api_key
+    source_api_key_hash = source.api_key_hash
+    source_settings_id = source.settings&.id
+    source_roles = source.roles.dup if source.roles
+
+    admin_login
+    visit "/admin/#/api_users/#{source.id}/edit"
+    assert_field("First Name", :with => "Source")
+
+    find("a.duplicate-action", :text => /Duplicate API User/).click
+
+    assert_current_path %r{/admin/#/api_users/new\?duplicate_id=#{source.id}}, :url => true
+    assert_text("Duplicated from #{source.email}")
+    assert_field("E-mail", :with => "")
+    assert_field("First Name", :with => "Source")
+    assert_field("Last Name", :with => "User")
+
+    fill_in("E-mail", :with => "duplicate.user@example.com")
+    label_check "User agrees to the terms and conditions"
+    click_button("Save")
+    assert_text("Successfully saved")
+
+    duplicate = ApiUser.where(:email => "duplicate.user@example.com").order(:created_at => :desc).first
+    refute_nil(duplicate, "duplicate user was created")
+    refute_equal(source_id, duplicate.id, "duplicate has fresh id")
+    refute_equal(source_email, duplicate.email, "duplicate has fresh email")
+    refute_equal(source_api_key, duplicate.api_key, "duplicate has fresh api_key")
+    refute_equal(source_api_key_hash, duplicate.api_key_hash, "duplicate has fresh api_key_hash")
+
+    if source.settings
+      refute_nil(duplicate.settings, "duplicate has settings")
+      refute_equal(source_settings_id, duplicate.settings.id, "duplicate settings has fresh id")
+    end
+
+    if source_roles
+      assert_equal(source_roles.sort, (duplicate.roles || []).sort, "duplicate roles preserved by value")
+    end
+
+    source.reload
+    assert_equal(source_email, source.email, "source email unchanged")
+    assert_equal(source_api_key, source.api_key, "source api_key unchanged")
+  end
 end

--- a/test/admin_ui/test_apis.rb
+++ b/test/admin_ui/test_apis.rb
@@ -432,4 +432,71 @@ class Test::AdminUi::TestApis < Minitest::Capybara::Test
       assert_select("HTTP Method", :selected => "OPTIONS")
     end
   end
+
+  def test_duplicate_creates_new_record_with_copied_data
+    source = FactoryBot.create(:api_backend_with_all_relationships, :name => "Source Backend Test")
+    source_id = source.id
+    source_server_ids = source.servers.map(&:id)
+    source_url_match_ids = source.url_matches.map(&:id)
+    source_settings_id = source.settings&.id
+    source_sub_settings_ids = source.sub_settings.map(&:id)
+    source_rewrites_ids = source.rewrites.map(&:id)
+
+    admin_login
+    visit "/admin/#/apis/#{source.id}/edit"
+    assert_field("Name", :with => "Source Backend Test")
+
+    find("a.duplicate-action", :text => /Duplicate API/).click
+
+    assert_current_path %r{/admin/#/apis/new\?duplicate_id=#{source.id}}, :url => true
+    assert_text("Duplicated from Source Backend Test")
+    assert_field("Name", :with => "Source Backend Test")
+    assert_field("Frontend Host", :with => source.frontend_host)
+
+    fill_in("Name", :with => "Duplicate Backend Test")
+    click_button("Save")
+    assert_text("Successfully saved")
+
+    duplicate = ApiBackend.where(:name => "Duplicate Backend Test").order(:created_at => :desc).first
+    refute_nil(duplicate, "duplicate backend was created")
+    refute_equal(source_id, duplicate.id, "duplicate has a different id from source")
+
+    assert_equal(source.servers.count, duplicate.servers.count, "duplicate has same number of servers")
+    duplicate.servers.each do |server|
+      refute_includes(source_server_ids, server.id, "duplicate server has fresh id")
+      assert_equal(duplicate.id, server.api_backend_id, "duplicate server FK points to duplicate")
+    end
+
+    assert_equal(source.url_matches.count, duplicate.url_matches.count, "duplicate has same number of url_matches")
+    duplicate.url_matches.each do |um|
+      refute_includes(source_url_match_ids, um.id, "duplicate url_match has fresh id")
+      assert_equal(duplicate.id, um.api_backend_id, "duplicate url_match FK points to duplicate")
+    end
+
+    if source.settings
+      refute_nil(duplicate.settings, "duplicate has settings")
+      refute_equal(source_settings_id, duplicate.settings.id, "duplicate settings has fresh id")
+      assert_equal(duplicate.id, duplicate.settings.api_backend_id, "duplicate settings FK points to duplicate")
+    end
+
+    assert_equal(source.sub_settings.count, duplicate.sub_settings.count, "duplicate has same number of sub_settings")
+    duplicate.sub_settings.each do |ss|
+      refute_includes(source_sub_settings_ids, ss.id, "duplicate sub-setting has fresh id")
+      assert_equal(duplicate.id, ss.api_backend_id, "duplicate sub-setting FK points to duplicate")
+      if ss.settings
+        refute_nil(ss.settings, "duplicate sub-setting has nested settings")
+        refute_includes([source_settings_id], ss.settings.id, "duplicate nested settings has fresh id")
+      end
+    end
+
+    assert_equal(source.rewrites.count, duplicate.rewrites.count, "duplicate has same number of rewrites")
+    duplicate.rewrites.each do |rw|
+      refute_includes(source_rewrites_ids, rw.id, "duplicate rewrite has fresh id")
+      assert_equal(duplicate.id, rw.api_backend_id, "duplicate rewrite FK points to duplicate")
+    end
+
+    source.reload
+    assert_equal("Source Backend Test", source.name, "source name unchanged")
+    assert_equal(source_server_ids.sort, source.servers.map(&:id).sort, "source servers unchanged")
+  end
 end

--- a/test/admin_ui/test_apis.rb
+++ b/test/admin_ui/test_apis.rb
@@ -499,4 +499,11 @@ class Test::AdminUi::TestApis < Minitest::Capybara::Test
     assert_equal("Source Backend Test", source.name, "source name unchanged")
     assert_equal(source_server_ids.sort, source.servers.map(&:id).sort, "source servers unchanged")
   end
+
+  def test_duplicate_link_hidden_on_new_form
+    admin_login
+    visit "/admin/#/apis/new"
+    assert_field("Name")
+    refute_selector("a.duplicate-action")
+  end
 end

--- a/test/admin_ui/test_website_backends.rb
+++ b/test/admin_ui/test_website_backends.rb
@@ -1,0 +1,52 @@
+require_relative "../test_helper"
+
+class Test::AdminUi::TestWebsiteBackends < Minitest::Capybara::Test
+  include Capybara::Screenshot::MiniTestPlugin
+  include ApiUmbrellaTestHelpers::AdminAuth
+  include ApiUmbrellaTestHelpers::Setup
+
+  def setup
+    super
+    setup_server
+  end
+
+  def test_duplicate_creates_new_record_with_copied_data
+    source = FactoryBot.create(:website_backend, :frontend_host => "source.example.com", :server_host => "backend.example.com", :server_port => 8080)
+    source_id = source.id
+    source_frontend_host = source.frontend_host
+    source_server_host = source.server_host
+    source_server_port = source.server_port
+
+    admin_login
+    visit "/admin/#/website_backends/#{source.id}/edit"
+    assert_field("Frontend Host", :with => "source.example.com")
+
+    find("a.duplicate-action", :text => /Duplicate Website Backend/).click
+
+    assert_current_path %r{/admin/#/website_backends/new\?duplicate_id=#{source.id}}, :url => true
+    assert_text("Duplicated from")
+    assert_field("Frontend Host", :with => "source.example.com")
+    assert_field("Backend Server", :with => "backend.example.com")
+    assert_field("Backend Port", :with => "8080")
+
+    fill_in("Frontend Host", :with => "duplicate.example.com")
+    click_button("Save")
+    assert_text("Successfully saved")
+
+    duplicate = WebsiteBackend.where(:frontend_host => "duplicate.example.com").order(:created_at => :desc).first
+    refute_nil(duplicate, "duplicate website-backend was created")
+    refute_equal(source_id, duplicate.id, "duplicate has fresh id")
+    assert_equal(source_server_host, duplicate.server_host, "server_host preserved")
+    assert_equal(source_server_port, duplicate.server_port, "server_port preserved")
+
+    source.reload
+    assert_equal(source_frontend_host, source.frontend_host, "source frontend_host unchanged")
+  end
+
+  def test_duplicate_link_hidden_on_new_form
+    admin_login
+    visit "/admin/#/website_backends/new"
+    assert_field("Frontend Host")
+    refute_selector("a.duplicate-action")
+  end
+end


### PR DESCRIPTION
<img width="221" height="166" alt="image" src="https://github.com/user-attachments/assets/cd4c06a3-fdda-4b6c-8df8-97006d8d3279" />

resolves https://github.com/18F/api.data.gov/issues/702

This gives each resource the ability to duplicate, and will cascade down to all it's child resources. 
I introduced a new service (src/api-umbrella/admin-ui/app/services/duplicate-record.js) that houses the bulk of the logic. Also added a util to wrap `Form` to cut down on boilerplate, but if that seems like too much abstraction it's unwindable.
There's a number of new tests to document what we'd expect to see here. 
Added the copy fontawesome icon as it seemed appropriate, but if there's another way to go here I missed lemme know!